### PR TITLE
Report error location in the parsed file, not only in the lens

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Mar 15 12:56:30 UTC 2018 - mvidner@suse.com
+
+- Distinguish between parsing and serializing in error reports.
+- Mention the file being parsed, and the position inside, in error
+  reports (bsc#1077435)
+- 0.6.4
+
+-------------------------------------------------------------------
 Thu Mar  8 07:13:41 UTC 2018 - jreidinger@suse.com
 
 - Workaround for augeas lenses that don't handle files without

--- a/cfa.gemspec
+++ b/cfa.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "cfa"
-  s.version     = "0.6.3"
+  s.version     = "0.6.4"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Josef Reidinger"]
   s.email       = ["jreidinger@suse.cz"]

--- a/lib/cfa/augeas_parser.rb
+++ b/lib/cfa/augeas_parser.rb
@@ -298,21 +298,25 @@ module CFA
   #    require "cfa/augeas_parser"
   #
   #    parser = CFA::AugeasParser.new("Sysconfig.lns")
+  #    parser.file_name = "/etc/default/grub" # for error reporting
   #    data = parser.parse(File.read("/etc/default/grub"))
   #
   #    puts data["GRUB_DISABLE_OS_PROBER"]
   #    data["GRUB_DISABLE_OS_PROBER"] = "true"
   #    puts parser.serialize(data)
   class AugeasParser
+    # @return [String] optional, used for error reporting
+    attr_accessor :file_name
+
     # @param lens [String] a lens name, like "Sysconfig.lns"
     def initialize(lens)
       @lens = lens
+      @file_name = nil
     end
 
     # @param raw_string [String] a string to be parsed
-    # @param file_name [String] a file name, for error reporting ONLY
     # @return [AugeasTree] the parsed data
-    def parse(raw_string, file_name = nil)
+    def parse(raw_string)
       require "cfa/augeas_parser/reader"
       # Workaround for augeas lenses that don't handle files
       # without a trailing newline (bsc#1064623, bsc#1074891, bsc#1080051
@@ -333,9 +337,8 @@ module CFA
     end
 
     # @param data [AugeasTree] the data to be serialized
-    # @param file_name [String] a file name, for error reporting ONLY
     # @return [String] a string to be written
-    def serialize(data, file_name = nil)
+    def serialize(data)
       require "cfa/augeas_parser/writer"
       # open augeas without any autoloading and it should not touch disk and
       # load lenses as needed only

--- a/lib/cfa/augeas_parser.rb
+++ b/lib/cfa/augeas_parser.rb
@@ -366,8 +366,8 @@ module CFA
     def report_error(aug, activity, file_name)
       error = aug.error
       # zero is no error, so problem in lense
-      if aug.error[:code].nonzero?
-        raise "Augeas error #{error[:message]}. Details: #{error[:details]}."
+      if error[:code].nonzero?
+        raise "Augeas error: #{error[:message]}. Details: #{error[:details]}."
       end
 
       file_name ||= "(unknown file)"

--- a/lib/cfa/base_model.rb
+++ b/lib/cfa/base_model.rb
@@ -39,7 +39,8 @@ module CFA
     #   insertion of such values in the first place.
     def save(changes_only: false)
       merge_changes if changes_only
-      @file_handler.write(@file_path, @parser.serialize(data, @file_path))
+      @parser.file_name = @file_path if @parser.respond_to?(:file_name=)
+      @file_handler.write(@file_path, @parser.serialize(data))
     end
 
     # Reads a String using *file_handler*
@@ -51,7 +52,8 @@ module CFA
     # @raise a *parser* specific error. If the parsed String is malformed, then
     #   depending on the used parser it may raise an error.
     def load
-      self.data = @parser.parse(@file_handler.read(@file_path), @file_path)
+      @parser.file_name = @file_path if @parser.respond_to?(:file_name=)
+      self.data = @parser.parse(@file_handler.read(@file_path))
       @loaded = true
     end
 

--- a/lib/cfa/base_model.rb
+++ b/lib/cfa/base_model.rb
@@ -39,7 +39,7 @@ module CFA
     #   insertion of such values in the first place.
     def save(changes_only: false)
       merge_changes if changes_only
-      @file_handler.write(@file_path, @parser.serialize(data))
+      @file_handler.write(@file_path, @parser.serialize(data, @file_path))
     end
 
     # Reads a String using *file_handler*
@@ -51,7 +51,7 @@ module CFA
     # @raise a *parser* specific error. If the parsed String is malformed, then
     #   depending on the used parser it may raise an error.
     def load
-      self.data = @parser.parse(@file_handler.read(@file_path))
+      self.data = @parser.parse(@file_handler.read(@file_path), @file_path)
       @loaded = true
     end
 

--- a/spec/augeas_parser_spec.rb
+++ b/spec/augeas_parser_spec.rb
@@ -24,10 +24,18 @@ describe CFA::AugeasParser do
     end
 
     it "raises exception if augeas failed during parsing" do
-      example_file = "invalid syntax\n"
+      example_file = "root ALL=(ALL) ALL\ninvalid syntax\n"
 
-      msg = /Augeas parsing error/
-      expect { subject.parse(example_file) }.to raise_error(msg)
+      msg = /Augeas parsing error: .* at \/dev\/garbage:2:0/
+      expect { subject.parse(example_file, "/dev/garbage") }.to raise_error(msg)
+    end
+
+    it "raises exception if augeas lens failed" do
+      example_file = "root ALL=(ALL) ALL\n"
+      bad_parser = described_class.new("nosuchlens.lns")
+
+      msg = /Augeas error: .* Details:/
+      expect { bad_parser.parse(example_file) }.to raise_error(msg)
     end
   end
 
@@ -49,8 +57,9 @@ describe CFA::AugeasParser do
       example_tree = CFA::AugeasTree.new
       example_tree["invalid"] = "test"
 
-      msg = /Augeas serializing error/
-      expect { subject.serialize(example_tree) }.to raise_error(msg)
+      msg = /Augeas serializing error: .* at \/etc\/sudoers::/
+      expect { subject.serialize(example_tree, "/etc/sudoers") }
+        .to raise_error(msg)
     end
   end
 

--- a/spec/augeas_parser_spec.rb
+++ b/spec/augeas_parser_spec.rb
@@ -25,9 +25,10 @@ describe CFA::AugeasParser do
 
     it "raises exception if augeas failed during parsing" do
       example_file = "root ALL=(ALL) ALL\ninvalid syntax\n"
+      subject.file_name = "/dev/garbage"
 
       msg = /Augeas parsing error: .* at \/dev\/garbage:2:0/
-      expect { subject.parse(example_file, "/dev/garbage") }.to raise_error(msg)
+      expect { subject.parse(example_file) }.to raise_error(msg)
     end
 
     it "raises exception if augeas lens failed" do
@@ -56,9 +57,10 @@ describe CFA::AugeasParser do
     it "raises exception if passed tree cannot be converted by augeas lens" do
       example_tree = CFA::AugeasTree.new
       example_tree["invalid"] = "test"
+      subject.file_name = "/etc/sudoers"
 
       msg = /Augeas serializing error: .* at \/etc\/sudoers::/
-      expect { subject.serialize(example_tree, "/etc/sudoers") }
+      expect { subject.serialize(example_tree) }
         .to raise_error(msg)
     end
   end

--- a/spec/augeas_parser_spec.rb
+++ b/spec/augeas_parser_spec.rb
@@ -26,7 +26,7 @@ describe CFA::AugeasParser do
     it "raises exception if augeas failed during parsing" do
       example_file = "invalid syntax\n"
 
-      msg = /Augeas parsing\/serializing error/
+      msg = /Augeas parsing error/
       expect { subject.parse(example_file) }.to raise_error(msg)
     end
   end
@@ -49,7 +49,7 @@ describe CFA::AugeasParser do
       example_tree = CFA::AugeasTree.new
       example_tree["invalid"] = "test"
 
-      msg = /Augeas parsing\/serializing error/
+      msg = /Augeas serializing error/
       expect { subject.serialize(example_tree) }.to raise_error(msg)
     end
   end


### PR DESCRIPTION
[bsc#1077435](https://bugzilla.suse.com/show_bug.cgi?id=1077435) but **note** that the bug is for SLE12-SP3 and this one is for master. Should I backport it? (Uh, there don't seem to be any maintenance branches for this...)

As seen in https://github.com/yast/yast-network/pull/603, when there's a problem with parsing a config file, we fail to tell the user which part of the config file is at fault.

Before:
> Client call failed with 'Augeas parsing/serializing error: Iterated lens matched less than it should at  /usr/share/augeas/lenses/dist/hosts.aug:23.12-.42:' (RuntimeError)

After:
> Client call failed with 'Augeas **parsing** error: Iterated lens matched less than it should at **/etc/hosts:34:0, lens** /usr/share/augeas/lenses/dist/hosts.aug:23.12-.42:' (RuntimeError)
