### PR TITLE
Append newline to read file contents

### DIFF
--- a/lib/cfa/base_model.rb
+++ b/lib/cfa/base_model.rb
@@ -51,7 +51,8 @@ module CFA
     # @raise a *parser* specific error. If the parsed String is malformed, then
     #   depending on the used parser it may raise an error.
     def load
-      self.data = @parser.parse(@file_handler.read(@file_path))
+      contents = @file_handler.read(@file_path)
+      self.data = @parser.parse(append_newline(contents))
       @loaded = true
     end
 
@@ -114,6 +115,13 @@ module CFA
     end
 
   protected
+
+    # Workaround for augeas lenses that don't handle files
+    # without a trailing newline
+    def append_newline(str)
+      return str if str[-1] == "\n"
+      str << "\n"
+    end
 
     def tree_value_plain(value)
       value.is_a?(AugeasTreeValue) ? value.value : value


### PR DESCRIPTION
This is a proposed workaround for augeas lenses that can't handle files without a trailing newline.

This seems to be a common issue with YaST ([bsc#1064623](https://bugzilla.suse.com/show_bug.cgi?id=1064623), [bsc#1074891](https://bugzilla.opensuse.org/show_bug.cgi?id=1074891), [bsc#1080051](https://bugzilla.suse.com/show_bug.cgi?id=1080051))

I asked about augeas people about the possibility of fixing this in augeas and the upstream maintainer would rather [prefer](https://github.com/hercules-team/augeas/issues/547#issuecomment-370590368) a fix in CFA.

Would you consider this workaround?