### PR TITLE
Frozen strings. Drop support for Ruby 2.2 and 2.3; add 2.6. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 rvm:
-  - 2.5.0
-  - 2.4.0
-  - 2.3.3
-  - 2.2.6
+  - 2.6.3
+  - 2.5.5
+  - 2.4.6
 addons:
   apt:
     packages:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jun 12 08:43:33 UTC 2019 - Martin Vidner <mvidner@suse.com>
+
+- Drop support for Ruby 2.2 and 2.3; add 2.6.
+
+-------------------------------------------------------------------
 Thu Nov  8 12:51:22 UTC 2018 - jreidinger@suse.com
 
 - Improve even more error reporting now with specialized exceptions

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,6 @@ group :development, :test do
 end
 
 group :development do
+  gem "rake"
   gem "rubocop"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gem "ruby-augeas"

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rake"
 require "rspec/core/rake_task"
 

--- a/cfa.gemspec
+++ b/cfa.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Gem::Specification.new do |s|
   s.name        = "cfa"
   s.version     = "0.7.0"

--- a/lib/cfa/augeas_parser.rb
+++ b/lib/cfa/augeas_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "set"
 require "augeas"
 require "forwardable"

--- a/lib/cfa/augeas_parser/keys_cache.rb
+++ b/lib/cfa/augeas_parser/keys_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CFA
   # A cache that holds all avaiable keys in an Augeas tree. It is used to
   # prevent too many `aug.match` calls which are expensive.

--- a/lib/cfa/augeas_parser/reader.rb
+++ b/lib/cfa/augeas_parser/reader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "cfa/augeas_parser/keys_cache"
 require "cfa/augeas_parser"
 

--- a/lib/cfa/augeas_parser/writer.rb
+++ b/lib/cfa/augeas_parser/writer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CFA
   # The goal of this class is to write the data stored in {AugeasTree}
   # back to Augeas.

--- a/lib/cfa/base_model.rb
+++ b/lib/cfa/base_model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "cfa/matcher"
 require "cfa/placer"
 # FIXME: tree should be generic and not augeas specific,

--- a/lib/cfa/base_model.rb
+++ b/lib/cfa/base_model.rb
@@ -192,15 +192,17 @@ module CFA
     end
 
     def enabled?
-      return nil unless data
+      d = data
+      return nil unless d
 
-      data == @true_value
+      d == @true_value
     end
 
     def disabled?
-      return nil unless data
+      d = data
+      return nil unless d
 
-      data != @true_value
+      d != @true_value
     end
 
     def defined?

--- a/lib/cfa/base_model.rb
+++ b/lib/cfa/base_model.rb
@@ -172,10 +172,16 @@ module CFA
     end
   end
 
-  # Representing boolean value switcher in default grub configuration file.
+  # Represents a boolean value switcher in default grub configuration file.
   # Allows easy switching and questioning for boolean value, even if
-  # represented by text in config file
+  # represented by text in config file.
+  # It's tristate: if unset, {#enabled?} and {#disabled?} return `nil`
+  # (but once set, we cannot return to an unset state).
   class BooleanValue
+    # @param name [String]
+    # @param model [BaseModel]
+    # @param true_value [String]
+    # @param false_value [String]
     def initialize(name, model, true_value: "true", false_value: "false")
       @name = name
       @model = model
@@ -183,14 +189,17 @@ module CFA
       @false_value = false_value
     end
 
+    # Set to *true*
     def enable
       @model.generic_set(@name, @true_value)
     end
 
+    # Set to *false*
     def disable
       @model.generic_set(@name, @false_value)
     end
 
+    # @return [Boolean,nil] true, false, (nil if undefined)
     def enabled?
       d = data
       return nil unless d
@@ -198,6 +207,7 @@ module CFA
       d == @true_value
     end
 
+    # @return [Boolean,nil] true, false, (nil if undefined)
     def disabled?
       d = data
       return nil unless d
@@ -205,12 +215,16 @@ module CFA
       d != @true_value
     end
 
+    # @return [Boolean]
+    #   true if the key has a value;
+    #   false if {#enabled?} and {#disabled?} return `nil`.
     def defined?
       !data.nil?
     end
 
     # sets boolean value, recommend to use for generic boolean setter.
     # for constants prefer to use enable/disable
+    # @param value [Boolean]
     def value=(value)
       @model.generic_set(@name, value ? @true_value : @false_value)
     end

--- a/lib/cfa/matcher.rb
+++ b/lib/cfa/matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CFA
   # The Matcher is used as a predicate on {AugeasElement}.
   #

--- a/lib/cfa/memory_file.rb
+++ b/lib/cfa/memory_file.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CFA
   # memory file is used when string is stored only in memory.
   # Useful for testing. For remote read or socket read, own File class

--- a/lib/cfa/placer.rb
+++ b/lib/cfa/placer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CFA
   # Places a new {AugeasElement} into an {AugeasTree}.
   # @abstract Subclasses implement different ways **where**
@@ -10,7 +12,7 @@ module CFA
     #     documents its structure.
     def new_element(_tree)
       raise NotImplementedError,
-        "Subclasses of #{Module.nesting.first} must override #{__method__}"
+            "Subclasses of #{Module.nesting.first} must override #{__method__}"
     end
 
   protected

--- a/performance_test/augeas_loader_test.rb
+++ b/performance_test/augeas_loader_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # use with `time ruby <path>` to test changes in library
 # goal of this tests are to measure time, for correctness is used
 # tests in spec directory

--- a/spec/augeas_collection_spec.rb
+++ b/spec/augeas_collection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "spec_helper"
 
 require "cfa/augeas_parser"

--- a/spec/augeas_parser_spec.rb
+++ b/spec/augeas_parser_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "spec_helper"
 
 require "cfa/augeas_parser"

--- a/spec/augeas_tree_spec.rb
+++ b/spec/augeas_tree_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "spec_helper"
 
 require "cfa/augeas_parser"

--- a/spec/augeas_writer_spec.rb
+++ b/spec/augeas_writer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "spec_helper"
 
 require "cfa/augeas_parser"

--- a/spec/base_model_spec.rb
+++ b/spec/base_model_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "spec_helper"
 require "cfa/augeas_parser"
 require "cfa/base_model"
@@ -6,7 +8,7 @@ require "cfa/memory_file"
 # A testing model
 class TestModel < CFA::BaseModel
   PARSER = CFA::AugeasParser.new("postgresql.lns")
-  PATH = "/var/lib/pgsql/postgresql.conf".freeze
+  PATH = "/var/lib/pgsql/postgresql.conf"
 
   attributes(
     port: "port",

--- a/spec/matcher_spec.rb
+++ b/spec/matcher_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "spec_helper"
 require "cfa/matcher"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 def load_data(path)


### PR DESCRIPTION
This is an "ecosystem maintenance" PR, in that we adapt to the world changing around us:

New RuboCop, which we use, stopped supporting Ruby 2.2, also 2.3 is out of maintenance by now

For the record, SLE 12 has Ruby 2.1, SLE 15 has Ruby 2.5.