### PR TITLE
[RFC] Add loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@ The second layer is the parser, that understands the structure
 of the configuration files. There are also several possible variants like augeas
 based, XML parsed by standard ruby library or CVS via cvs specialized library.
 
-The third layer are the loaders and writers, which are able to merge the data
-from different files for cases where the configuration is spread accross
-several files. For instance, think about the typical `<example>.d` directories,
-like `pam.d`.
+The third layer are the loaders, which are able to merge the data from different
+files for cases where the configuration is spread accross several files. For
+instance, think about the typical `<example>.d` directories, like `pam.d`.
 
 The fourth layer consist on a set of models representing the configuration to
 provide more high level actions. Its main purposes are to ensure consistency of

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ CFA - Config Files Api Gem
 [![Code Climate](https://codeclimate.com/github/config-files-api/config_files_api/badges/gpa.svg)](https://codeclimate.com/github/config-files-api/config_files_api)
 [![Coverage Status](https://coveralls.io/repos/config-files-api/config_files_api/badge.svg?branch=master&service=github)](https://coveralls.io/github/config-files-api/config_files_api?branch=master)
 Ruby gem providing a modular and developer friendly way to access and modify
-configuration files in a  system. It's structured in three layers.
+configuration files in a  system. It's structured in four layers.
 
 The first layer provides access to the file and its content. By default it
 accesses the local system, but it can be replaced by alternatives to work
@@ -14,7 +14,12 @@ The second layer is the parser, that understands the structure
 of the configuration files. There are also several possible variants like augeas
 based, XML parsed by standard ruby library or CVS via cvs specialized library.
 
-The third layer consist on a set of models representing the files to provide
-more high level actions. Its main purposes are to ensure consistency of the
-files and to provide high level API for manipulating the files. The models
+The third layer are the loaders and writers, which are able to merge the data
+from different files for cases where the configuration is spread accross
+several files. For instance, think about the typical `<example>.d` directories,
+like `pam.d`.
+
+The fourth layer consist on a set of models representing the configuration to
+provide more high level actions. Its main purposes are to ensure consistency of
+the configuration and to provide high level API for manipulating it. The models
 live in their own gems as plugins built on top of this gem.

--- a/lib/cfa/augeas_parser.rb
+++ b/lib/cfa/augeas_parser.rb
@@ -212,14 +212,6 @@ module CFA
       @data.reject { |e| e[:operation] == :remove }.freeze
     end
 
-    # TODO
-    #
-    # @param _other [AugeasTree]
-    # @return [AugeasTree]
-    def merge(_other)
-      self
-    end
-
     # low level access to all AugeasElement including ones marked for removal
     def all_data
       @data
@@ -304,6 +296,34 @@ module CFA
     # @return [Array<AugeasElement>] matching elements
     def select(matcher)
       data.select(&matcher)
+    end
+
+    # Returns a copy of the tree
+    #
+    # @return [AugeasTree]
+    def copy
+      Marshal.load(Marshal.dump(self))
+    end
+
+    # Merges two augeas tree
+    #
+    # Information from both trees is merged, building a new one.
+    #
+    # TODO: The implementation is not finished yet. Support for comments and
+    # arrays are still missing.
+    #
+    # @param other [AugeasTree]
+    # @return [AugeasTree]
+    # @see #[]=
+    def merge(other)
+      other.data.each_with_object(self.copy) do |e, merged|
+        next if e[:key] == "#comment[]"
+        if e[:value].is_a?(AugeasTree) && merged[e[:key]]
+          merged[e[:key]] = merged[e[:key]].merge(e[:value])
+        else
+          merged[e[:key]] = e[:value]
+        end
+      end
     end
 
     def ==(other)

--- a/lib/cfa/augeas_parser.rb
+++ b/lib/cfa/augeas_parser.rb
@@ -212,6 +212,14 @@ module CFA
       @data.reject { |e| e[:operation] == :remove }.freeze
     end
 
+    # TODO
+    #
+    # @param _other [AugeasTree]
+    # @return [AugeasTree]
+    def merge(_other)
+      self
+    end
+
     # low level access to all AugeasElement including ones marked for removal
     def all_data
       @data

--- a/lib/cfa/augeas_parser.rb
+++ b/lib/cfa/augeas_parser.rb
@@ -198,6 +198,7 @@ module CFA
   end
 
   # Represents a parsed Augeas config tree with user friendly methods
+  # rubocop:disable Metrics/ClassLength
   class AugeasTree
     # Low level access to Augeas structure
     #
@@ -316,13 +317,14 @@ module CFA
     # @return [AugeasTree]
     # @see #[]=
     def merge(other)
-      other.data.each_with_object(self.copy) do |e, merged|
+      other.data.each_with_object(copy) do |e, merged|
         next if e[:key] == "#comment[]"
-        if e[:value].is_a?(AugeasTree) && merged[e[:key]]
-          merged[e[:key]] = merged[e[:key]].merge(e[:value])
-        else
-          merged[e[:key]] = e[:value]
-        end
+
+        merged[e[:key]] = if e[:value].is_a?(AugeasTree) && merged[e[:key]]
+                            merged[e[:key]].merge(e[:value])
+                          else
+                            e[:value]
+                          end
       end
     end
 
@@ -387,6 +389,7 @@ module CFA
       new_entry
     end
   end
+  # rubocop:enable Metrics/ClassLength
 
   # @example read, print, modify and serialize again
   #    require "cfa/augeas_parser"

--- a/lib/cfa/base_model.rb
+++ b/lib/cfa/base_model.rb
@@ -23,12 +23,13 @@ module CFA
     #   It has to provide methods `string read(string)` and
     #   `write(string, string)`. For an example see {CFA::MemoryFile}.
     #   If unspecified or `nil`, {.default_file_handler} is asked.
-    def initialize(parser, file_path, file_handler: nil,
-      load_handler: CFA::Loader)
+    def initialize(parser, file_path, file_handler: nil, load_handler: nil)
       @file_handler = file_handler || BaseModel.default_file_handler
       @parser = parser
       @file_path = file_path
-      @load_handler = load_handler
+      @load_handler = load_handler || CFA::Loader.new(
+        parser: @parser, file_handler: @file_handler, file_path: @file_path
+      )
       @loaded = false
       self.data = parser.empty
     end
@@ -56,10 +57,7 @@ module CFA
     # @raise a *parser* specific error. If the parsed String is malformed, then
     #   depending on the used parser it may raise an error.
     def load
-      loader = @load_handler.new(
-        parser: @parser, file_handler: @file_handler, file_path: @file_path
-      )
-      self.data = loader.load
+      self.data = @load_handler.load
       @loaded = true
     end
 

--- a/lib/cfa/base_model.rb
+++ b/lib/cfa/base_model.rb
@@ -23,7 +23,8 @@ module CFA
     #   It has to provide methods `string read(string)` and
     #   `write(string, string)`. For an example see {CFA::MemoryFile}.
     #   If unspecified or `nil`, {.default_file_handler} is asked.
-    def initialize(parser, file_path, file_handler: nil, load_handler: CFA::Loader)
+    def initialize(parser, file_path, file_handler: nil,
+      load_handler: CFA::Loader)
       @file_handler = file_handler || BaseModel.default_file_handler
       @parser = parser
       @file_path = file_path

--- a/lib/cfa/base_model.rb
+++ b/lib/cfa/base_model.rb
@@ -2,6 +2,7 @@
 
 require "cfa/matcher"
 require "cfa/placer"
+require "cfa/loader"
 # FIXME: tree should be generic and not augeas specific,
 # not needed in 1.0 as planned
 require "cfa/augeas_parser"
@@ -22,10 +23,11 @@ module CFA
     #   It has to provide methods `string read(string)` and
     #   `write(string, string)`. For an example see {CFA::MemoryFile}.
     #   If unspecified or `nil`, {.default_file_handler} is asked.
-    def initialize(parser, file_path, file_handler: nil)
+    def initialize(parser, file_path, file_handler: nil, load_handler: CFA::Loader)
       @file_handler = file_handler || BaseModel.default_file_handler
       @parser = parser
       @file_path = file_path
+      @load_handler = load_handler
       @loaded = false
       self.data = parser.empty
     end
@@ -53,8 +55,10 @@ module CFA
     # @raise a *parser* specific error. If the parsed String is malformed, then
     #   depending on the used parser it may raise an error.
     def load
-      @parser.file_name = @file_path if @parser.respond_to?(:file_name=)
-      self.data = @parser.parse(@file_handler.read(@file_path))
+      loader = @load_handler.new(
+        parser: @parser, file_handler: @file_handler, file_path: @file_path
+      )
+      self.data = loader.load
       @loaded = true
     end
 

--- a/lib/cfa/base_model.rb
+++ b/lib/cfa/base_model.rb
@@ -111,7 +111,7 @@ module CFA
           tree_value_plain(generic_get(key))
         end
 
-        define_method(:"#{method_name.to_s}=") do |value|
+        define_method(:"#{method_name}=") do |value|
           tree_value_change(key, value)
         end
       end

--- a/lib/cfa/base_model.rb
+++ b/lib/cfa/base_model.rb
@@ -44,8 +44,7 @@ module CFA
     #   A properly written BaseModel subclass should prevent that by preventing
     #   insertion of such values in the first place.
     def save
-      @parser.file_name = @file_path if @parser.respond_to?(:file_name=)
-      @file_handler.write(@file_path, @parser.serialize(data))
+      @load_handler.save(data)
     end
 
     # Reads a String using *file_handler*

--- a/lib/cfa/loader.rb
+++ b/lib/cfa/loader.rb
@@ -44,6 +44,10 @@ module CFA
       load_file(file_path)
     end
 
+    def save(data)
+      save_file(file_path, data)
+    end
+
   private
 
     attr_reader :parser, :file_handler, :file_path
@@ -51,6 +55,11 @@ module CFA
     def load_file(path)
       @parser.file_name = path if @parser.respond_to?(:file_name=)
       @parser.parse(@file_handler.read(path))
+    end
+
+    def save_file(path, data)
+      @parser.file_name = path if @parser.respond_to?(:file_name=)
+      @file_handler.write(path, @parser.serialize(data))
     end
   end
 end

--- a/lib/cfa/loader.rb
+++ b/lib/cfa/loader.rb
@@ -48,9 +48,9 @@ module CFA
 
     attr_reader :parser, :file_handler, :file_path
 
-    def load_file(file_path)
-      @parser.file_name = file_path if @parser.respond_to?(:file_name=)
-      @parser.parse(@file_handler.read(file_path))
+    def load_file(path)
+      @parser.file_name = path if @parser.respond_to?(:file_name=)
+      @parser.parse(@file_handler.read(path))
     end
   end
 end

--- a/lib/cfa/loader.rb
+++ b/lib/cfa/loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) [2019] SUSE LLC
 #
 # All Rights Reserved.
@@ -20,8 +22,9 @@
 module CFA
   # This class is responsible for loading a file using a parser.
   #
-  # {Loader} can be specialized to support more complex scenarios, like reading configuration
-  # information from different sources. See {VendorLoader} for an example.
+  # {Loader} can be specialized to support more complex scenarios, like reading
+  # configuration information from different sources. See {VendorLoader} for an
+  # example.
   #
   # @example Loading and merging configuration files
   #   loader = Loader.new(

--- a/lib/cfa/loader.rb
+++ b/lib/cfa/loader.rb
@@ -1,0 +1,53 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module CFA
+  # This class is responsible for loading a file using a parser.
+  #
+  # {Loader} can be specialized to support more complex scenarios, like reading configuration
+  # information from different sources. See {VendorLoader} for an example.
+  #
+  # @example Loading and merging configuration files
+  #   loader = Loader.new(
+  #     parser: AugeasParser.new("sysconfig.lns"),
+  #     file_handler: File,
+  #     file_path: "/etc/zypp/zypp.conf"
+  #   ) #=> #<CFA::Loader:...>
+  #   content = loader.load #=> #<CFA::AugeasTree:...>
+  class Loader
+    def initialize(parser:, file_handler:, file_path:)
+      @parser = parser
+      @file_handler = file_handler
+      @file_path = file_path
+    end
+
+    def load
+      load_file(file_path)
+    end
+
+  private
+
+    attr_reader :parser, :file_handler, :file_path
+
+    def load_file(file_path)
+      @parser.file_name = file_path if @parser.respond_to?(:file_name=)
+      @parser.parse(@file_handler.read(file_path))
+    end
+  end
+end

--- a/lib/cfa/vendor_loader.rb
+++ b/lib/cfa/vendor_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) [2019] SUSE LLC
 #
 # All Rights Reserved.
@@ -22,8 +24,8 @@ require "cfa/loader"
 module CFA
   # Loader to read and combine information from different files
   #
-  # Given an +/etc/example.conf+, this class loads information from
-  # different places. If +/etc/example.conf+ exists, the information is read from:
+  # Given an +/etc/example.conf+, this class loads information from different
+  # places. If +/etc/example.conf+ exists, the information is read from:
   #
   # * +/etc/example.conf+
   # * +/etc/example.d/*+
@@ -34,13 +36,15 @@ module CFA
   # * +/usr/etc/example.d/*+
   # * +/etc/example.d/*+
   class VendorLoader < Loader
-    VENDOR_PREFIX = "/usr/etc".freeze
+    VENDOR_PREFIX = "/usr/etc"
     CUSTOM_PREFIX = "/etc"
 
     attr_reader :vendor_prefix
     attr_reader :custom_prefix
 
-    def initialize(parser:, file_handler:, file_path:, vendor_prefix: nil, custom_prefix: nil)
+    def initialize(
+      parser:, file_handler:, file_path:, vendor_prefix: nil, custom_prefix: nil
+    )
       super(parser: parser, file_handler: file_handler, file_path: file_path)
       @vendor_prefix = vendor_prefix || VENDOR_PREFIX
       @custom_prefix = custom_prefix || CUSTOM_PREFIX
@@ -63,8 +67,8 @@ module CFA
           [file_path, override_paths(file_path)]
         else
           rel_file_path = file_path.sub(/\A#{custom_prefix}/, "")
-          vendor_file_path = File.join(vendor_prefix, rel_file_path)
-          [vendor_file_path, override_paths(vendor_file_path), override_paths(file_path)]
+          vendor_path = File.join(vendor_prefix, rel_file_path)
+          [vendor_path, override_paths(vendor_path), override_paths(file_path)]
         end
       Dir.glob(globs)
     end

--- a/lib/cfa/vendor_loader.rb
+++ b/lib/cfa/vendor_loader.rb
@@ -62,9 +62,15 @@ module CFA
     end
 
     def save(data)
-      conf_path = File.join(
-        override_dir(file_path), "#{FILE_ORDER}-yast.conf"
-      )
+      conf_path =
+        if File.exist?(override_dir(file_path))
+          file_path
+        else
+          # FIXME: allow to specify a pattern to build the override name
+          File.join(
+            override_dir(file_path), "#{FILE_ORDER}-yast.conf"
+          )
+        end
       save_file(conf_path, data)
     end
 

--- a/lib/cfa/vendor_loader.rb
+++ b/lib/cfa/vendor_loader.rb
@@ -38,6 +38,7 @@ module CFA
   class VendorLoader < Loader
     VENDOR_PREFIX = "/usr/etc"
     CUSTOM_PREFIX = "/etc"
+    FILE_ORDER = 50
 
     attr_reader :vendor_prefix
     attr_reader :custom_prefix
@@ -60,6 +61,13 @@ module CFA
       end
     end
 
+    def save(data)
+      conf_path = File.join(
+        override_dir(file_path), "#{FILE_ORDER}-yast.conf"
+      )
+      save_file(conf_path, data)
+    end
+
     # @return [Array<String>]
     def paths
       globs =
@@ -76,8 +84,12 @@ module CFA
     # @param path [String]
     # @return [Array<String>]
     def override_paths(path)
+      File.join(override_dir(path), "*")
+    end
+
+    def override_dir(path)
       ext = File.extname(path)
-      File.join(path.sub(/#{ext}$/, ".d"), "*")
+      path.sub(/#{ext}$/, ".d")
     end
   end
 end

--- a/lib/cfa/vendor_loader.rb
+++ b/lib/cfa/vendor_loader.rb
@@ -1,0 +1,79 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "cfa/loader"
+
+module CFA
+  # Loader to read and combine information from different files
+  #
+  # Given an +/etc/example.conf+, this class loads information from
+  # different places. If +/etc/example.conf+ exists, the information is read from:
+  #
+  # * +/etc/example.conf+
+  # * +/etc/example.d/*+
+  #
+  # If it does not exist, it will use:
+  #
+  # * +/usr/etc/example.conf+
+  # * +/usr/etc/example.d/*+
+  # * +/etc/example.d/*+
+  class VendorLoader < Loader
+    VENDOR_PREFIX = "/usr/etc".freeze
+    CUSTOM_PREFIX = "/etc"
+
+    attr_reader :vendor_prefix
+    attr_reader :custom_prefix
+
+    def initialize(parser:, file_handler:, file_path:, vendor_prefix: nil, custom_prefix: nil)
+      super(parser: parser, file_handler: file_handler, file_path: file_path)
+      @vendor_prefix = vendor_prefix || VENDOR_PREFIX
+      @custom_prefix = custom_prefix || CUSTOM_PREFIX
+    end
+
+    # Returns merged file contents.
+    #
+    # @return [Object] File content (usually {AugeasTree}).
+    def load
+      contents = paths.map { |n| load_file(n) }
+      contents.reduce(parser.empty) do |all_content, file|
+        all_content.merge(file)
+      end
+    end
+
+    # @return [Array<String>]
+    def paths
+      globs =
+        if File.exist?(file_path)
+          [file_path, override_paths(file_path)]
+        else
+          rel_file_path = file_path.sub(/\A#{custom_prefix}/, "")
+          vendor_file_path = File.join(vendor_prefix, rel_file_path)
+          [vendor_file_path, override_paths(vendor_file_path), override_paths(file_path)]
+        end
+      Dir.glob(globs)
+    end
+
+    # @param path [String]
+    # @return [Array<String>]
+    def override_paths(path)
+      ext = File.extname(path)
+      File.join(path.sub(/#{ext}$/, ".d"), "*")
+    end
+  end
+end

--- a/spec/augeas_tree_spec.rb
+++ b/spec/augeas_tree_spec.rb
@@ -151,4 +151,34 @@ describe CFA::AugeasTree do
       expect(example_tree == other_tree).to eq(false)
     end
   end
+
+  describe "#merge" do
+    let(:other) do
+      CFA::AugeasTree.new.tap do |tree|
+        tree.add("#comment", "sample comment")
+        tree.add("debug", "no")
+      end
+    end
+
+    before do
+      tree.add("debug", "yes")
+    end
+
+    it "merges simple values" do
+      merged = tree.merge(other)
+      expect(merged["debug"]).to eq("no")
+    end
+
+    it "merges subtrees"
+
+    it "merges arrays"
+  end
+
+  describe "#copy" do
+    it "returns a copy of the object" do
+      copy = tree.copy
+      expect(copy).to eq(tree)
+      expect(copy).to_not be(tree)
+    end
+  end
 end

--- a/spec/data/etc/dnsmasq.conf
+++ b/spec/data/etc/dnsmasq.conf
@@ -1,0 +1,679 @@
+# Configuration file for dnsmasq.
+#
+# Format is one option per line, legal options are the same
+# as the long options legal on the command line. See
+# "/usr/sbin/dnsmasq --help" or "man 8 dnsmasq" for details.
+
+# Listen on this specific port instead of the standard DNS port
+# (53). Setting this to zero completely disables DNS function,
+# leaving only DHCP and/or TFTP.
+#port=5353
+
+# The following two options make you a better netizen, since they
+# tell dnsmasq to filter out queries which the public DNS cannot
+# answer, and which load the servers (especially the root servers)
+# unnecessarily. If you have a dial-on-demand link they also stop
+# these requests from bringing up the link unnecessarily.
+
+# Never forward plain names (without a dot or domain part)
+#domain-needed
+# Never forward addresses in the non-routed address spaces.
+#bogus-priv
+
+# Uncomment these to enable DNSSEC validation and caching:
+# (Requires dnsmasq to be built with DNSSEC option.)
+#conf-file=/etc/dnsmasq.d/trust-anchors.conf
+#dnssec
+
+# Replies which are not DNSSEC signed may be legitimate, because the domain
+# is unsigned, or may be forgeries. Setting this option tells dnsmasq to
+# check that an unsigned reply is OK, by finding a secure proof that a DS 
+# record somewhere between the root and the domain does not exist. 
+# The cost of setting this is that even queries in unsigned domains will need
+# one or more extra DNS queries to verify.
+#dnssec-check-unsigned
+
+# Uncomment this to filter useless windows-originated DNS requests
+# which can trigger dial-on-demand links needlessly.
+# Note that (amongst other things) this blocks all SRV requests,
+# so don't use it if you use eg Kerberos, SIP, XMMP or Google-talk.
+# This option only affects forwarding, SRV records originating for
+# dnsmasq (via srv-host= lines) are not suppressed by it.
+#filterwin2k
+
+# Change this line if you want dns to get its upstream servers from
+# somewhere other that /etc/resolv.conf
+#resolv-file=
+
+# By  default,  dnsmasq  will  send queries to any of the upstream
+# servers it knows about and tries to favour servers to are  known
+# to  be  up.  Uncommenting this forces dnsmasq to try each query
+# with  each  server  strictly  in  the  order  they   appear   in
+# /etc/resolv.conf
+#strict-order
+
+# If you don't want dnsmasq to read /etc/resolv.conf or any other
+# file, getting its servers from this file instead (see below), then
+# uncomment this.
+#no-resolv
+
+# If you don't want dnsmasq to poll /etc/resolv.conf or other resolv
+# files for changes and re-read them then uncomment this.
+#no-poll
+
+# Add other name servers here, with domain specs if they are for
+# non-public domains.
+#server=/localnet/192.168.0.1
+
+# Example of routing PTR queries to nameservers: this will send all
+# address->name queries for 192.168.3/24 to nameserver 10.1.2.3
+#server=/3.168.192.in-addr.arpa/10.1.2.3
+
+# Add local-only domains here, queries in these domains are answered
+# from /etc/hosts or DHCP only.
+#local=/localnet/
+
+# Add domains which you want to force to an IP address here.
+# The example below send any host in double-click.net to a local
+# web-server.
+#address=/double-click.net/127.0.0.1
+
+# --address (and --server) work with IPv6 addresses too.
+#address=/www.thekelleys.org.uk/fe80::20d:60ff:fe36:f83
+
+# Add the IPs of all queries to yahoo.com, google.com, and their
+# subdomains to the vpn and search ipsets:
+#ipset=/yahoo.com/google.com/vpn,search
+
+# You can control how dnsmasq talks to a server: this forces
+# queries to 10.1.2.3 to be routed via eth1
+# server=10.1.2.3@eth1
+
+# and this sets the source (ie local) address used to talk to
+# 10.1.2.3 to 192.168.1.1 port 55 (there must be an interface with that
+# IP on the machine, obviously).
+# server=10.1.2.3@192.168.1.1#55
+
+# If you want dnsmasq to change uid and gid to something other
+# than the default, edit the following lines.
+#user=
+#group=
+
+# If you want dnsmasq to listen for DHCP and DNS requests only on
+# specified interfaces (and the loopback) give the name of the
+# interface (eg eth0) here.
+# Repeat the line for more than one interface.
+#interface=
+# Or you can specify which interface _not_ to listen on
+#except-interface=
+# Or which to listen on by address (remember to include 127.0.0.1 if
+# you use this.)
+#listen-address=
+# If you want dnsmasq to provide only DNS service on an interface,
+# configure it as shown above, and then use the following line to
+# disable DHCP and TFTP on it.
+#no-dhcp-interface=
+
+# On systems which support it, dnsmasq binds the wildcard address,
+# even when it is listening on only some interfaces. It then discards
+# requests that it shouldn't reply to. This has the advantage of
+# working even when interfaces come and go and change address. If you
+# want dnsmasq to really bind only the interfaces it is listening on,
+# uncomment this option. About the only time you may need this is when
+# running another nameserver on the same machine.
+#bind-interfaces
+
+# If you don't want dnsmasq to read /etc/hosts, uncomment the
+# following line.
+#no-hosts
+# or if you want it to read another file, as well as /etc/hosts, use
+# this.
+#addn-hosts=/etc/banner_add_hosts
+
+# Set this (and domain: see below) if you want to have a domain
+# automatically added to simple names in a hosts-file.
+#expand-hosts
+
+# Set the domain for dnsmasq. this is optional, but if it is set, it
+# does the following things.
+# 1) Allows DHCP hosts to have fully qualified domain names, as long
+#     as the domain part matches this setting.
+# 2) Sets the "domain" DHCP option thereby potentially setting the
+#    domain of all systems configured by DHCP
+# 3) Provides the domain part for "expand-hosts"
+#domain=thekelleys.org.uk
+
+# Set a different domain for a particular subnet
+#domain=wireless.thekelleys.org.uk,192.168.2.0/24
+
+# Same idea, but range rather then subnet
+#domain=reserved.thekelleys.org.uk,192.68.3.100,192.168.3.200
+
+# Uncomment this to enable the integrated DHCP server, you need
+# to supply the range of addresses available for lease and optionally
+# a lease time. If you have more than one network, you will need to
+# repeat this for each network on which you want to supply DHCP
+# service.
+#dhcp-range=192.168.0.50,192.168.0.150,12h
+
+# This is an example of a DHCP range where the netmask is given. This
+# is needed for networks we reach the dnsmasq DHCP server via a relay
+# agent. If you don't know what a DHCP relay agent is, you probably
+# don't need to worry about this.
+#dhcp-range=192.168.0.50,192.168.0.150,255.255.255.0,12h
+
+# This is an example of a DHCP range which sets a tag, so that
+# some DHCP options may be set only for this network.
+#dhcp-range=set:red,192.168.0.50,192.168.0.150
+
+# Use this DHCP range only when the tag "green" is set.
+#dhcp-range=tag:green,192.168.0.50,192.168.0.150,12h
+
+# Specify a subnet which can't be used for dynamic address allocation,
+# is available for hosts with matching --dhcp-host lines. Note that
+# dhcp-host declarations will be ignored unless there is a dhcp-range
+# of some type for the subnet in question.
+# In this case the netmask is implied (it comes from the network
+# configuration on the machine running dnsmasq) it is possible to give
+# an explicit netmask instead.
+#dhcp-range=192.168.0.0,static
+
+# Enable DHCPv6. Note that the prefix-length does not need to be specified
+# and defaults to 64 if missing/
+#dhcp-range=1234::2, 1234::500, 64, 12h
+
+# Do Router Advertisements, BUT NOT DHCP for this subnet.
+#dhcp-range=1234::, ra-only 
+
+# Do Router Advertisements, BUT NOT DHCP for this subnet, also try and
+# add names to the DNS for the IPv6 address of SLAAC-configured dual-stack 
+# hosts. Use the DHCPv4 lease to derive the name, network segment and 
+# MAC address and assume that the host will also have an
+# IPv6 address calculated using the SLAAC algorithm.
+#dhcp-range=1234::, ra-names
+
+# Do Router Advertisements, BUT NOT DHCP for this subnet.
+# Set the lifetime to 46 hours. (Note: minimum lifetime is 2 hours.)
+#dhcp-range=1234::, ra-only, 48h
+
+# Do DHCP and Router Advertisements for this subnet. Set the A bit in the RA
+# so that clients can use SLAAC addresses as well as DHCP ones.
+#dhcp-range=1234::2, 1234::500, slaac
+
+# Do Router Advertisements and stateless DHCP for this subnet. Clients will
+# not get addresses from DHCP, but they will get other configuration information.
+# They will use SLAAC for addresses.
+#dhcp-range=1234::, ra-stateless
+
+# Do stateless DHCP, SLAAC, and generate DNS names for SLAAC addresses
+# from DHCPv4 leases.
+#dhcp-range=1234::, ra-stateless, ra-names
+
+# Do router advertisements for all subnets where we're doing DHCPv6
+# Unless overridden by ra-stateless, ra-names, et al, the router 
+# advertisements will have the M and O bits set, so that the clients
+# get addresses and configuration from DHCPv6, and the A bit reset, so the 
+# clients don't use SLAAC addresses.
+#enable-ra
+
+# Supply parameters for specified hosts using DHCP. There are lots
+# of valid alternatives, so we will give examples of each. Note that
+# IP addresses DO NOT have to be in the range given above, they just
+# need to be on the same network. The order of the parameters in these
+# do not matter, it's permissible to give name, address and MAC in any
+# order.
+
+# Always allocate the host with Ethernet address 11:22:33:44:55:66
+# The IP address 192.168.0.60
+#dhcp-host=11:22:33:44:55:66,192.168.0.60
+
+# Always set the name of the host with hardware address
+# 11:22:33:44:55:66 to be "fred"
+#dhcp-host=11:22:33:44:55:66,fred
+
+# Always give the host with Ethernet address 11:22:33:44:55:66
+# the name fred and IP address 192.168.0.60 and lease time 45 minutes
+#dhcp-host=11:22:33:44:55:66,fred,192.168.0.60,45m
+
+# Give a host with Ethernet address 11:22:33:44:55:66 or
+# 12:34:56:78:90:12 the IP address 192.168.0.60. Dnsmasq will assume
+# that these two Ethernet interfaces will never be in use at the same
+# time, and give the IP address to the second, even if it is already
+# in use by the first. Useful for laptops with wired and wireless
+# addresses.
+#dhcp-host=11:22:33:44:55:66,12:34:56:78:90:12,192.168.0.60
+
+# Give the machine which says its name is "bert" IP address
+# 192.168.0.70 and an infinite lease
+#dhcp-host=bert,192.168.0.70,infinite
+
+# Always give the host with client identifier 01:02:02:04
+# the IP address 192.168.0.60
+#dhcp-host=id:01:02:02:04,192.168.0.60
+
+# Always give the InfiniBand interface with hardware address
+# 80:00:00:48:fe:80:00:00:00:00:00:00:f4:52:14:03:00:28:05:81 the
+# ip address 192.168.0.61. The client id is derived from the prefix
+# ff:00:00:00:00:00:02:00:00:02:c9:00 and the last 8 pairs of
+# hex digits of the hardware address.
+#dhcp-host=id:ff:00:00:00:00:00:02:00:00:02:c9:00:f4:52:14:03:00:28:05:81,192.168.0.61
+
+# Always give the host with client identifier "marjorie"
+# the IP address 192.168.0.60
+#dhcp-host=id:marjorie,192.168.0.60
+
+# Enable the address given for "judge" in /etc/hosts
+# to be given to a machine presenting the name "judge" when
+# it asks for a DHCP lease.
+#dhcp-host=judge
+
+# Never offer DHCP service to a machine whose Ethernet
+# address is 11:22:33:44:55:66
+#dhcp-host=11:22:33:44:55:66,ignore
+
+# Ignore any client-id presented by the machine with Ethernet
+# address 11:22:33:44:55:66. This is useful to prevent a machine
+# being treated differently when running under different OS's or
+# between PXE boot and OS boot.
+#dhcp-host=11:22:33:44:55:66,id:*
+
+# Send extra options which are tagged as "red" to
+# the machine with Ethernet address 11:22:33:44:55:66
+#dhcp-host=11:22:33:44:55:66,set:red
+
+# Send extra options which are tagged as "red" to
+# any machine with Ethernet address starting 11:22:33:
+#dhcp-host=11:22:33:*:*:*,set:red
+
+# Give a fixed IPv6 address and name to client with 
+# DUID 00:01:00:01:16:d2:83:fc:92:d4:19:e2:d8:b2
+# Note the MAC addresses CANNOT be used to identify DHCPv6 clients.
+# Note also that the [] around the IPv6 address are obligatory.
+#dhcp-host=id:00:01:00:01:16:d2:83:fc:92:d4:19:e2:d8:b2, fred, [1234::5] 
+
+# Ignore any clients which are not specified in dhcp-host lines
+# or /etc/ethers. Equivalent to ISC "deny unknown-clients".
+# This relies on the special "known" tag which is set when
+# a host is matched.
+#dhcp-ignore=tag:!known
+
+# Send extra options which are tagged as "red" to any machine whose
+# DHCP vendorclass string includes the substring "Linux"
+#dhcp-vendorclass=set:red,Linux
+
+# Send extra options which are tagged as "red" to any machine one
+# of whose DHCP userclass strings includes the substring "accounts"
+#dhcp-userclass=set:red,accounts
+
+# Send extra options which are tagged as "red" to any machine whose
+# MAC address matches the pattern.
+#dhcp-mac=set:red,00:60:8C:*:*:*
+
+# If this line is uncommented, dnsmasq will read /etc/ethers and act
+# on the ethernet-address/IP pairs found there just as if they had
+# been given as --dhcp-host options. Useful if you keep
+# MAC-address/host mappings there for other purposes.
+#read-ethers
+
+# Send options to hosts which ask for a DHCP lease.
+# See RFC 2132 for details of available options.
+# Common options can be given to dnsmasq by name:
+# run "dnsmasq --help dhcp" to get a list.
+# Note that all the common settings, such as netmask and
+# broadcast address, DNS server and default route, are given
+# sane defaults by dnsmasq. You very likely will not need
+# any dhcp-options. If you use Windows clients and Samba, there
+# are some options which are recommended, they are detailed at the
+# end of this section.
+
+# Override the default route supplied by dnsmasq, which assumes the
+# router is the same machine as the one running dnsmasq.
+#dhcp-option=3,1.2.3.4
+
+# Do the same thing, but using the option name
+#dhcp-option=option:router,1.2.3.4
+
+# Override the default route supplied by dnsmasq and send no default
+# route at all. Note that this only works for the options sent by
+# default (1, 3, 6, 12, 28) the same line will send a zero-length option
+# for all other option numbers.
+#dhcp-option=3
+
+# Set the NTP time server addresses to 192.168.0.4 and 10.10.0.5
+#dhcp-option=option:ntp-server,192.168.0.4,10.10.0.5
+
+# Send DHCPv6 option. Note [] around IPv6 addresses.
+#dhcp-option=option6:dns-server,[1234::77],[1234::88]
+
+# Send DHCPv6 option for namservers as the machine running 
+# dnsmasq and another.
+#dhcp-option=option6:dns-server,[::],[1234::88]
+
+# Ask client to poll for option changes every six hours. (RFC4242)
+#dhcp-option=option6:information-refresh-time,6h
+
+# Set option 58 client renewal time (T1). Defaults to half of the
+# lease time if not specified. (RFC2132)
+#dhcp-option=option:T1,1m
+
+# Set option 59 rebinding time (T2). Defaults to 7/8 of the
+# lease time if not specified. (RFC2132)
+#dhcp-option=option:T2,2m
+
+# Set the NTP time server address to be the same machine as
+# is running dnsmasq
+#dhcp-option=42,0.0.0.0
+
+# Set the NIS domain name to "welly"
+#dhcp-option=40,welly
+
+# Set the default time-to-live to 50
+#dhcp-option=23,50
+
+# Set the "all subnets are local" flag
+#dhcp-option=27,1
+
+# Send the etherboot magic flag and then etherboot options (a string).
+#dhcp-option=128,e4:45:74:68:00:00
+#dhcp-option=129,NIC=eepro100
+
+# Specify an option which will only be sent to the "red" network
+# (see dhcp-range for the declaration of the "red" network)
+# Note that the tag: part must precede the option: part.
+#dhcp-option = tag:red, option:ntp-server, 192.168.1.1
+
+# The following DHCP options set up dnsmasq in the same way as is specified
+# for the ISC dhcpcd in
+# http://www.samba.org/samba/ftp/docs/textdocs/DHCP-Server-Configuration.txt
+# adapted for a typical dnsmasq installation where the host running
+# dnsmasq is also the host running samba.
+# you may want to uncomment some or all of them if you use
+# Windows clients and Samba.
+#dhcp-option=19,0           # option ip-forwarding off
+#dhcp-option=44,0.0.0.0     # set netbios-over-TCP/IP nameserver(s) aka WINS server(s)
+#dhcp-option=45,0.0.0.0     # netbios datagram distribution server
+#dhcp-option=46,8           # netbios node type
+
+# Send an empty WPAD option. This may be REQUIRED to get windows 7 to behave.
+#dhcp-option=252,"\n"
+
+# Send RFC-3397 DNS domain search DHCP option. WARNING: Your DHCP client
+# probably doesn't support this......
+#dhcp-option=option:domain-search,eng.apple.com,marketing.apple.com
+
+# Send RFC-3442 classless static routes (note the netmask encoding)
+#dhcp-option=121,192.168.1.0/24,1.2.3.4,10.0.0.0/8,5.6.7.8
+
+# Send vendor-class specific options encapsulated in DHCP option 43.
+# The meaning of the options is defined by the vendor-class so
+# options are sent only when the client supplied vendor class
+# matches the class given here. (A substring match is OK, so "MSFT"
+# matches "MSFT" and "MSFT 5.0"). This example sets the
+# mtftp address to 0.0.0.0 for PXEClients.
+#dhcp-option=vendor:PXEClient,1,0.0.0.0
+
+# Send microsoft-specific option to tell windows to release the DHCP lease
+# when it shuts down. Note the "i" flag, to tell dnsmasq to send the
+# value as a four-byte integer - that's what microsoft wants. See
+# http://technet2.microsoft.com/WindowsServer/en/library/a70f1bb7-d2d4-49f0-96d6-4b7414ecfaae1033.mspx?mfr=true
+#dhcp-option=vendor:MSFT,2,1i
+
+# Send the Encapsulated-vendor-class ID needed by some configurations of
+# Etherboot to allow is to recognise the DHCP server.
+#dhcp-option=vendor:Etherboot,60,"Etherboot"
+
+# Send options to PXELinux. Note that we need to send the options even
+# though they don't appear in the parameter request list, so we need
+# to use dhcp-option-force here.
+# See http://syslinux.zytor.com/pxe.php#special for details.
+# Magic number - needed before anything else is recognised
+#dhcp-option-force=208,f1:00:74:7e
+# Configuration file name
+#dhcp-option-force=209,configs/common
+# Path prefix
+#dhcp-option-force=210,/tftpboot/pxelinux/files/
+# Reboot time. (Note 'i' to send 32-bit value)
+#dhcp-option-force=211,30i
+
+# Set the boot filename for netboot/PXE. You will only need
+# this if you want to boot machines over the network and you will need
+# a TFTP server; either dnsmasq's built-in TFTP server or an
+# external one. (See below for how to enable the TFTP server.)
+#dhcp-boot=pxelinux.0
+
+# The same as above, but use custom tftp-server instead machine running dnsmasq
+#dhcp-boot=pxelinux,server.name,192.168.1.100
+
+# Boot for iPXE. The idea is to send two different
+# filenames, the first loads iPXE, and the second tells iPXE what to
+# load. The dhcp-match sets the ipxe tag for requests from iPXE.
+#dhcp-boot=undionly.kpxe
+#dhcp-match=set:ipxe,175 # iPXE sends a 175 option.
+#dhcp-boot=tag:ipxe,http://boot.ipxe.org/demo/boot.php
+
+# Encapsulated options for iPXE. All the options are
+# encapsulated within option 175
+#dhcp-option=encap:175, 1, 5b         # priority code
+#dhcp-option=encap:175, 176, 1b       # no-proxydhcp
+#dhcp-option=encap:175, 177, string   # bus-id
+#dhcp-option=encap:175, 189, 1b       # BIOS drive code
+#dhcp-option=encap:175, 190, user     # iSCSI username
+#dhcp-option=encap:175, 191, pass     # iSCSI password
+
+# Test for the architecture of a netboot client. PXE clients are
+# supposed to send their architecture as option 93. (See RFC 4578)
+#dhcp-match=peecees, option:client-arch, 0 #x86-32
+#dhcp-match=itanics, option:client-arch, 2 #IA64
+#dhcp-match=hammers, option:client-arch, 6 #x86-64
+#dhcp-match=mactels, option:client-arch, 7 #EFI x86-64
+
+# Do real PXE, rather than just booting a single file, this is an
+# alternative to dhcp-boot.
+#pxe-prompt="What system shall I netboot?"
+# or with timeout before first available action is taken:
+#pxe-prompt="Press F8 for menu.", 60
+
+# Available boot services. for PXE.
+#pxe-service=x86PC, "Boot from local disk"
+
+# Loads <tftp-root>/pxelinux.0 from dnsmasq TFTP server.
+#pxe-service=x86PC, "Install Linux", pxelinux
+
+# Loads <tftp-root>/pxelinux.0 from TFTP server at 1.2.3.4.
+# Beware this fails on old PXE ROMS.
+#pxe-service=x86PC, "Install Linux", pxelinux, 1.2.3.4
+
+# Use bootserver on network, found my multicast or broadcast.
+#pxe-service=x86PC, "Install windows from RIS server", 1
+
+# Use bootserver at a known IP address.
+#pxe-service=x86PC, "Install windows from RIS server", 1, 1.2.3.4
+
+# If you have multicast-FTP available,
+# information for that can be passed in a similar way using options 1
+# to 5. See page 19 of
+# http://download.intel.com/design/archives/wfm/downloads/pxespec.pdf
+
+
+# Enable dnsmasq's built-in TFTP server
+#enable-tftp
+
+# Set the root directory for files available via FTP.
+#tftp-root=/var/ftpd
+
+# Do not abort if the tftp-root is unavailable
+#tftp-no-fail
+
+# Make the TFTP server more secure: with this set, only files owned by
+# the user dnsmasq is running as will be send over the net.
+#tftp-secure
+
+# This option stops dnsmasq from negotiating a larger blocksize for TFTP
+# transfers. It will slow things down, but may rescue some broken TFTP
+# clients.
+#tftp-no-blocksize
+
+# Set the boot file name only when the "red" tag is set.
+#dhcp-boot=tag:red,pxelinux.red-net
+
+# An example of dhcp-boot with an external TFTP server: the name and IP
+# address of the server are given after the filename.
+# Can fail with old PXE ROMS. Overridden by --pxe-service.
+#dhcp-boot=/var/ftpd/pxelinux.0,boothost,192.168.0.3
+
+# If there are multiple external tftp servers having a same name
+# (using /etc/hosts) then that name can be specified as the
+# tftp_servername (the third option to dhcp-boot) and in that
+# case dnsmasq resolves this name and returns the resultant IP
+# addresses in round robin fashion. This facility can be used to
+# load balance the tftp load among a set of servers.
+#dhcp-boot=/var/ftpd/pxelinux.0,boothost,tftp_server_name
+
+# Set the limit on DHCP leases, the default is 150
+#dhcp-lease-max=150
+
+# The DHCP server needs somewhere on disk to keep its lease database.
+# This defaults to a sane location, but if you want to change it, use
+# the line below.
+#dhcp-leasefile=/var/lib/misc/dnsmasq.leases
+
+# Set the DHCP server to authoritative mode. In this mode it will barge in
+# and take over the lease for any client which broadcasts on the network,
+# whether it has a record of the lease or not. This avoids long timeouts
+# when a machine wakes up on a new network. DO NOT enable this if there's
+# the slightest chance that you might end up accidentally configuring a DHCP
+# server for your campus/company accidentally. The ISC server uses
+# the same option, and this URL provides more information:
+# http://www.isc.org/files/auth.html
+#dhcp-authoritative
+
+# Set the DHCP server to enable DHCPv4 Rapid Commit Option per RFC 4039.
+# In this mode it will respond to a DHCPDISCOVER message including a Rapid Commit
+# option with a DHCPACK including a Rapid Commit option and fully committed address
+# and configuration information. This must only be enabled if either the server is 
+# the only server for the subnet, or multiple servers are present and they each
+# commit a binding for all clients.
+#dhcp-rapid-commit
+
+# Run an executable when a DHCP lease is created or destroyed.
+# The arguments sent to the script are "add" or "del",
+# then the MAC address, the IP address and finally the hostname
+# if there is one.
+#dhcp-script=/bin/echo
+
+# Set the cachesize here.
+#cache-size=150
+
+# If you want to disable negative caching, uncomment this.
+#no-negcache
+
+# Normally responses which come from /etc/hosts and the DHCP lease
+# file have Time-To-Live set as zero, which conventionally means
+# do not cache further. If you are happy to trade lower load on the
+# server for potentially stale date, you can set a time-to-live (in
+# seconds) here.
+#local-ttl=
+
+# If you want dnsmasq to detect attempts by Verisign to send queries
+# to unregistered .com and .net hosts to its sitefinder service and
+# have dnsmasq instead return the correct NXDOMAIN response, uncomment
+# this line. You can add similar lines to do the same for other
+# registries which have implemented wildcard A records.
+#bogus-nxdomain=64.94.110.11
+
+# If you want to fix up DNS results from upstream servers, use the
+# alias option. This only works for IPv4.
+# This alias makes a result of 1.2.3.4 appear as 5.6.7.8
+#alias=1.2.3.4,5.6.7.8
+# and this maps 1.2.3.x to 5.6.7.x
+#alias=1.2.3.0,5.6.7.0,255.255.255.0
+# and this maps 192.168.0.10->192.168.0.40 to 10.0.0.10->10.0.0.40
+#alias=192.168.0.10-192.168.0.40,10.0.0.0,255.255.255.0
+
+# Change these lines if you want dnsmasq to serve MX records.
+
+# Return an MX record named "maildomain.com" with target
+# servermachine.com and preference 50
+#mx-host=maildomain.com,servermachine.com,50
+
+# Set the default target for MX records created using the localmx option.
+#mx-target=servermachine.com
+
+# Return an MX record pointing to the mx-target for all local
+# machines.
+#localmx
+
+# Return an MX record pointing to itself for all local machines.
+#selfmx
+
+# Change the following lines if you want dnsmasq to serve SRV
+# records.  These are useful if you want to serve ldap requests for
+# Active Directory and other windows-originated DNS requests.
+# See RFC 2782.
+# You may add multiple srv-host lines.
+# The fields are <name>,<target>,<port>,<priority>,<weight>
+# If the domain part if missing from the name (so that is just has the
+# service and protocol sections) then the domain given by the domain=
+# config option is used. (Note that expand-hosts does not need to be
+# set for this to work.)
+
+# A SRV record sending LDAP for the example.com domain to
+# ldapserver.example.com port 389
+#srv-host=_ldap._tcp.example.com,ldapserver.example.com,389
+
+# A SRV record sending LDAP for the example.com domain to
+# ldapserver.example.com port 389 (using domain=)
+#domain=example.com
+#srv-host=_ldap._tcp,ldapserver.example.com,389
+
+# Two SRV records for LDAP, each with different priorities
+#srv-host=_ldap._tcp.example.com,ldapserver.example.com,389,1
+#srv-host=_ldap._tcp.example.com,ldapserver.example.com,389,2
+
+# A SRV record indicating that there is no LDAP server for the domain
+# example.com
+#srv-host=_ldap._tcp.example.com
+
+# The following line shows how to make dnsmasq serve an arbitrary PTR
+# record. This is useful for DNS-SD. (Note that the
+# domain-name expansion done for SRV records _does_not
+# occur for PTR records.)
+#ptr-record=_http._tcp.dns-sd-services,"New Employee Page._http._tcp.dns-sd-services"
+
+# Change the following lines to enable dnsmasq to serve TXT records.
+# These are used for things like SPF and zeroconf. (Note that the
+# domain-name expansion done for SRV records _does_not
+# occur for TXT records.)
+
+#Example SPF.
+#txt-record=example.com,"v=spf1 a -all"
+
+#Example zeroconf
+#txt-record=_http._tcp.example.com,name=value,paper=A4
+
+# Provide an alias for a "local" DNS name. Note that this _only_ works
+# for targets which are names from DHCP or /etc/hosts. Give host
+# "bert" another name, bertrand
+#cname=bertand,bert
+
+# For debugging purposes, log each DNS query as it passes through
+# dnsmasq.
+#log-queries
+
+# Log lots of extra information about DHCP transactions.
+#log-dhcp
+
+# Include another lot of configuration options.
+#conf-file=/etc/dnsmasq.more.conf
+#conf-dir=/etc/dnsmasq.d
+
+# Include all the files in a directory except those ending in .bak
+#conf-dir=/etc/dnsmasq.d,.bak
+
+# Include all files in a directory which end in .conf
+#conf-dir=/etc/dnsmasq.d/,*.conf
+
+# If a DHCP client claims that its name is "wpad", ignore that.
+# This fixes a security hole. see CERT Vulnerability VU#598349
+#dhcp-name-match=set:wpad-ignore,wpad
+#dhcp-ignore-names=tag:wpad-ignore

--- a/spec/data/etc/sysctl.d/50-yast.conf
+++ b/spec/data/etc/sysctl.d/50-yast.conf
@@ -1,0 +1,1 @@
+net.ipv4.ip_forward = 1

--- a/spec/data/usr/etc/sysctl.conf
+++ b/spec/data/usr/etc/sysctl.conf
@@ -1,0 +1,12 @@
+####
+#
+# To disable or override a distribution provided file just place a
+# file with the same name in /etc/sysctl.d/
+#
+# See sysctl.conf(5), sysctl.d(5) and sysctl(8) for more information
+#
+####
+net.ipv4.ip_forward = 0
+net.ipv6.conf.all.forwarding = 0
+
+# net.ipv6.conf.all.disable_ipv6 = 1

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -1,0 +1,41 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "cfa/loader"
+require "cfa/augeas_parser"
+
+describe CFA::Loader do
+  subject { CFA::Loader.new(parser: parser, file_handler: File, file_path: file_path) }
+  let(:parser) { CFA::AugeasParser.new("sysconfig.lns") }
+  let(:file_path) { "/etc/zypp/zypp.conf" }
+
+  describe "#load" do
+    before do
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(file_path).and_return("arch=s390\n")
+    end
+
+    it "reads file content" do
+      expect(parser).to receive(:file_name=).with(file_path)
+      tree = subject.load
+      expect(tree["arch"]).to eq("s390")
+    end
+  end
+end

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -42,4 +42,16 @@ describe CFA::Loader do
       expect(tree["arch"]).to eq("s390")
     end
   end
+
+  describe "#save" do
+    before do
+      allow(parser).to receive(:serialize).and_return("foo=bar")
+    end
+
+    it "writes the content to the file path" do
+      expect(parser).to receive(:file_name=).with("/etc/zypp/zypp.conf")
+      expect(File).to receive(:write).with("/etc/zypp/zypp.conf", "foo=bar")
+      subject.save({})
+    end
+  end
 end

--- a/spec/loader_spec.rb
+++ b/spec/loader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) [2019] SUSE LLC
 #
 # All Rights Reserved.
@@ -22,7 +24,9 @@ require "cfa/loader"
 require "cfa/augeas_parser"
 
 describe CFA::Loader do
-  subject { CFA::Loader.new(parser: parser, file_handler: File, file_path: file_path) }
+  subject do
+    CFA::Loader.new(parser: parser, file_handler: File, file_path: file_path)
+  end
   let(:parser) { CFA::AugeasParser.new("sysconfig.lns") }
   let(:file_path) { "/etc/zypp/zypp.conf" }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
+DATA_PATH = File.expand_path("data", __dir__)
+
 def load_data(path)
   File.read(File.expand_path("data/#{path}", __dir__))
 end

--- a/spec/vendor_loader_spec.rb
+++ b/spec/vendor_loader_spec.rb
@@ -33,6 +33,7 @@ describe CFA::VendorLoader do
   let(:parser) { CFA::AugeasParser.new(lense) }
   let(:vendor_prefix) { File.join(DATA_PATH, "usr", "etc") }
   let(:custom_prefix) { File.join(DATA_PATH, "etc") }
+  let(:lense) { "sysctl.lns" }
 
   describe "#load" do
     before do
@@ -81,6 +82,22 @@ describe CFA::VendorLoader do
           .with(File.join(custom_prefix, "sysctl.d", "50-yast.conf"))
         loader.load
       end
+    end
+  end
+
+  describe "#save" do
+    let(:file_path) { File.join(custom_prefix, "sysctl.conf") }
+
+    before do
+      allow(parser).to receive(:serialize).and_return("foo=bar")
+    end
+
+    it "writes the content to .d directory" do
+      conf_file = File.join(custom_prefix, "sysctl.d", "50-yast.conf")
+      expect(parser).to receive(:file_name=)
+        .with(conf_file)
+      expect(File).to receive(:write).with(conf_file, "foo=bar")
+      subject.save({})
     end
   end
 end

--- a/spec/vendor_loader_spec.rb
+++ b/spec/vendor_loader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) [2019] SUSE LLC
 #
 # All Rights Reserved.
@@ -24,7 +26,8 @@ require "cfa/augeas_parser"
 describe CFA::VendorLoader do
   subject(:loader) do
     CFA::VendorLoader.new(
-      parser: parser, file_handler: File, file_path: file_path, vendor_prefix: vendor_prefix, custom_prefix: custom_prefix
+      parser: parser, file_handler: File, file_path: file_path,
+      vendor_prefix: vendor_prefix, custom_prefix: custom_prefix
     )
   end
   let(:parser) { CFA::AugeasParser.new(lense) }

--- a/spec/vendor_loader_spec.rb
+++ b/spec/vendor_loader_spec.rb
@@ -1,0 +1,83 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "spec_helper"
+require "cfa/vendor_loader"
+require "cfa/augeas_parser"
+
+describe CFA::VendorLoader do
+  subject(:loader) do
+    CFA::VendorLoader.new(
+      parser: parser, file_handler: File, file_path: file_path, vendor_prefix: vendor_prefix, custom_prefix: custom_prefix
+    )
+  end
+  let(:parser) { CFA::AugeasParser.new(lense) }
+  let(:vendor_prefix) { File.join(DATA_PATH, "usr", "etc") }
+  let(:custom_prefix) { File.join(DATA_PATH, "etc") }
+
+  describe "#load" do
+    before do
+      allow(loader).to receive(:load_file).and_call_original
+    end
+
+    context "when the .conf file in /etc exists" do
+      let(:lense) { "dnsmasq.lns" }
+      let(:file_path) { File.join(custom_prefix, "dnsmasq.conf") }
+
+      it "does not read the vendor files" do
+        expect(loader).to_not receive(:load_file)
+          .with(/usr\/etc/)
+        loader.load
+      end
+
+      it "reads the custom .conf file" do
+        expect(loader).to receive(:load_file)
+          .with(File.join(custom_prefix, "dnsmasq.conf"))
+        loader.load
+      end
+
+      it "reads the files under the .d directory" do
+        expect(loader).to receive(:load_file)
+          .with(File.join(custom_prefix, "dnsmasq.d", "50-yast.conf"))
+        loader.load
+      end
+    end
+
+    context "when the .conf file in /etc does not exists" do
+      let(:lense) { "sysctl.lns" }
+      let(:file_path) { File.join(DATA_PATH, "etc", "sysctl.conf") }
+
+      before do
+        allow(loader).to receive(:load_file).and_call_original
+      end
+
+      it "reads the vendor files" do
+        expect(loader).to receive(:load_file)
+          .with(File.join(vendor_prefix, "sysctl.conf"))
+        loader.load
+      end
+
+      it "reads the files under the .d directory" do
+        expect(loader).to receive(:load_file)
+          .with(File.join(custom_prefix, "sysctl.d", "50-yast.conf"))
+        loader.load
+      end
+    end
+  end
+end


### PR DESCRIPTION
In some cases, the configuration is built after reading and merging the content from different files. Let's think about `.d` directories or having the vendor configuration in `/usr/etc` and the user one in `/etc`.

This PR explores the possibility of extracting the logic to decide which file(s) to load to a separate class. Parsers and file handlers are not modified, though, which is the point of adding additional classes.

These new classes are named *loaders*. For the usual case (reading from a single file), there is a `Loader` class. For complex cases, like the `/usr/etc` and `/etc` separation, a `VendorLoader` class exists.

# TODO

- [x] Pass the loader as an instance
- [ ] Improve documentation
- [x] Add a mechanism to write changes
- [ ] Rename `Loader` and `VendorLoader`